### PR TITLE
feat: Implement on-disk mirroring for the FUSE filesystem

### DIFF
--- a/src/disk_image.rs
+++ b/src/disk_image.rs
@@ -1,6 +1,7 @@
 use std::{
     fs,
-    path::PathBuf,
+    os::unix::fs::{chown, symlink, PermissionsExt},
+    path::{Path, PathBuf},
     sync::{
         mpsc::{self, Sender},
         Arc, RwLock,
@@ -8,6 +9,7 @@ use std::{
     thread::{self, JoinHandle},
 };
 
+use fuser::FileAttr;
 use log::{debug, info};
 
 use crate::node::{FileContent, NodeKind, Nodes};
@@ -26,29 +28,51 @@ impl DiskImage {
         Self { base_path }
     }
 
-    pub fn path_for_ino(&self, ino: u64) -> PathBuf {
-        self.base_path.join(ino.to_string())
-    }
-
-    pub fn write(&self, ino: u64, data: &[u8]) -> std::io::Result<()> {
-        info!("Writing to disk ino: {ino}");
-        fs::write(self.path_for_ino(ino), data)
-    }
-
-    pub fn read(&self, ino: u64) -> std::io::Result<Vec<u8>> {
-        info!("Reading from disk ino: {ino}");
-        fs::read(self.path_for_ino(ino))
-    }
-
-    pub fn remove(&self, ino: u64) -> std::io::Result<()> {
-        info!("Removing from disk ino: {ino}");
-        fs::remove_file(self.path_for_ino(ino))
+    pub fn get_fs_path(&self, path: &Path) -> PathBuf {
+        let relative_path = if path.has_root() {
+            path.strip_prefix("/").unwrap()
+        } else {
+            path
+        };
+        self.base_path.join(relative_path)
     }
 }
 
+#[derive(Debug)]
 pub enum WriteJob {
-    Write { ino: u64, data: Vec<u8> },
-    Delete { ino: u64 },
+    CreateFile {
+        path: PathBuf,
+        attr: FileAttr,
+    },
+    CreateDir {
+        path: PathBuf,
+        attr: FileAttr,
+    },
+    CreateSymlink {
+        path: PathBuf,
+        target: PathBuf,
+        attr: FileAttr,
+    },
+    Write {
+        ino: u64,
+        path: PathBuf,
+        data: Vec<u8>,
+    },
+    SetAttr {
+        path: PathBuf,
+        attr: FileAttr,
+    },
+    Delete {
+        path: PathBuf,
+    },
+    Rename {
+        old_path: PathBuf,
+        new_path: PathBuf,
+    },
+    Link {
+        source_path: PathBuf,
+        link_path: PathBuf,
+    },
 }
 
 pub struct DiskImageWorker {
@@ -68,28 +92,8 @@ impl DiskImageWorker {
         let worker_disk_image = disk_image.clone();
         let worker_thread = thread::spawn(move || {
             for job in rx {
-                match job {
-                    WriteJob::Write { ino, data } => {
-                        if let Err(e) = worker_disk_image.write(ino, &data) {
-                            debug!("Failed to write {ino} to disk: {e:?}");
-                            continue;
-                        }
-                        let mut nodes = nodes.write().unwrap();
-                        if let Ok(node) = nodes.get_mut(ino) {
-                            if let NodeKind::File { content } = &mut node.kind {
-                                if let FileContent::Dirty(mem_data) = content {
-                                    if mem_data.as_slice() == data.as_slice() {
-                                        *content = FileContent::OnDisk;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    WriteJob::Delete { ino } => {
-                        if let Err(e) = worker_disk_image.remove(ino) {
-                            debug!("Failed to remove {ino} from disk: {e:?}");
-                        }
-                    }
+                if let Err(e) = Self::handle_job(&worker_disk_image, &nodes, job) {
+                    debug!("Failed to execute write job: {e:?}");
                 }
             }
         });
@@ -100,6 +104,91 @@ impl DiskImageWorker {
             worker_thread: Some(worker_thread),
         }
     }
+
+    fn handle_job(
+        disk_image: &DiskImage,
+        nodes: &Arc<RwLock<Nodes>>,
+        job: WriteJob,
+    ) -> std::io::Result<()> {
+        debug!("Executing job: {job:?}");
+        match job {
+            WriteJob::CreateFile { path, attr } => {
+                let fs_path = disk_image.get_fs_path(&path);
+                if let Some(parent) = fs_path.parent() {
+                    fs::create_dir_all(parent)?;
+                }
+                fs::File::create(&fs_path)?;
+                let perm = fs::Permissions::from_mode(attr.perm as u32);
+                fs::set_permissions(&fs_path, perm)?;
+                chown(&fs_path, Some(attr.uid), Some(attr.gid))?;
+            }
+            WriteJob::CreateDir { path, attr } => {
+                let fs_path = disk_image.get_fs_path(&path);
+                fs::create_dir_all(&fs_path)?;
+                let perm = fs::Permissions::from_mode(attr.perm as u32);
+                fs::set_permissions(&fs_path, perm)?;
+                chown(&fs_path, Some(attr.uid), Some(attr.gid))?;
+            }
+            WriteJob::CreateSymlink { path, target, attr } => {
+                let fs_path = disk_image.get_fs_path(&path);
+                if let Some(parent) = fs_path.parent() {
+                    fs::create_dir_all(parent)?;
+                }
+                symlink(&target, &fs_path)?;
+                chown(&fs_path, Some(attr.uid), Some(attr.gid))?;
+            }
+            WriteJob::Write { ino, path, data } => {
+                let fs_path = disk_image.get_fs_path(&path);
+                fs::write(&fs_path, &data)?;
+
+                let mut nodes = nodes.write().unwrap();
+                if let Ok(node) = nodes.get_mut(ino) {
+                    if let NodeKind::File { content } = &mut node.kind {
+                        if let FileContent::Dirty(mem_data) = content {
+                            if mem_data.as_slice() == data.as_slice() {
+                                *content = FileContent::OnDisk;
+                            }
+                        }
+                    }
+                }
+            }
+            WriteJob::SetAttr { path, attr } => {
+                let fs_path = disk_image.get_fs_path(&path);
+                let perm = fs::Permissions::from_mode(attr.perm as u32);
+                fs::set_permissions(&fs_path, perm)?;
+                chown(&fs_path, Some(attr.uid), Some(attr.gid))?;
+                if let Ok(file) = fs::OpenOptions::new().write(true).open(&fs_path) {
+                    file.set_len(attr.size)?;
+                }
+            }
+            WriteJob::Delete { path } => {
+                let fs_path = disk_image.get_fs_path(&path);
+                if fs_path.is_dir() {
+                    fs::remove_dir(fs_path)?;
+                } else {
+                    fs::remove_file(fs_path)?;
+                }
+            }
+            WriteJob::Rename { old_path, new_path } => {
+                let old_fs_path = disk_image.get_fs_path(&old_path);
+                let new_fs_path = disk_image.get_fs_path(&new_path);
+                fs::rename(old_fs_path, new_fs_path)?;
+            }
+            WriteJob::Link {
+                source_path,
+                link_path,
+            } => {
+                let source_fs_path = disk_image.get_fs_path(&source_path);
+                let link_fs_path = disk_image.get_fs_path(&link_path);
+                if let Some(parent) = link_fs_path.parent() {
+                    fs::create_dir_all(parent)?;
+                }
+                fs::hard_link(source_fs_path, link_fs_path)?;
+            }
+        }
+        Ok(())
+    }
+
 
     pub fn sender(&self) -> Sender<WriteJob> {
         self.work_queue.clone()


### PR DESCRIPTION
I have now implemented on-disk mirroring for the FUSE filesystem.

I modified the `disk_image` module to maintain a complete, parallel copy of the in-memory file system on disk. The on-disk mirror replicates the full directory structure, filenames, symbolic links, and file attributes (permissions and ownership).

Here is a summary of the key changes I made:
- I added a parent-tracking mechanism to the in-memory node representation to allow for efficient path resolution of any file or directory.
- I overhauled the `DiskImage` module to perform path-based file system operations instead of storing data in a flat, inode-keyed structure.
- I expanded the `WriteJob` enum to represent a wide range of file system operations (create, rename, link, unlink, setattr, etc.).
- I updated the logic to process these jobs and execute the mirroring operations asynchronously.
- I also updated all relevant FUSE handlers in `mem_fuse.rs` to dispatch jobs for processing, which keeps the on-disk mirror synchronized with the in-memory state.
- Finally, I added a comprehensive test suite to verify the correctness of the disk mirroring for various file system operations.

Written by Jules