### PR TITLE
feat: Only write dirty regions to disk

### DIFF
--- a/src/dirty.rs
+++ b/src/dirty.rs
@@ -1,0 +1,52 @@
+use std::collections::BTreeSet;
+
+#[derive(Debug, Default)]
+pub struct DirtyRegions {
+    regions: BTreeSet<(u64, u64)>,
+}
+
+impl DirtyRegions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add_region(&mut self, start: u64, end: u64) {
+        if start >= end {
+            return;
+        }
+
+        let mut new_regions = BTreeSet::new();
+        let mut merged_start = start;
+        let mut merged_end = end;
+
+        for &(r_start, r_end) in self.regions.iter() {
+            if r_end < start || r_start > end {
+                new_regions.insert((r_start, r_end));
+            } else {
+                merged_start = merged_start.min(r_start);
+                merged_end = merged_end.max(r_end);
+            }
+        }
+
+        new_regions.insert((merged_start, merged_end));
+        self.regions = new_regions;
+    }
+
+    pub fn regions(&self) -> &BTreeSet<(u64, u64)> {
+        &self.regions
+    }
+
+    pub fn clear(&mut self) {
+        self.regions.clear();
+    }
+
+    pub fn truncate(&mut self, size: u64) {
+        let mut new_regions = BTreeSet::new();
+        for &(start, end) in self.regions.iter() {
+            if start < size {
+                new_regions.insert((start, end.min(size)));
+            }
+        }
+        self.regions = new_regions;
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use std::result::Result;
 mod disk_image;
 mod mem_fuse;
 mod node;
+mod dirty;
 
 #[derive(Debug, Parser)]
 #[command(name = "inv-fuse")]


### PR DESCRIPTION
Previously, every write operation, no matter how small, would cause the entire file content to be written to the disk. This was inefficient and could cause background disk writing to fall behind.

This change introduces a mechanism to track "dirty regions" within each file. When a write or truncate operation occurs, the affected byte ranges are recorded. This information is now used to only write the modified portions of the file to disk, using `pwrite` for efficient partial writes.

To support this, the in-memory representation of file content has been changed to use an `Arc<RwLock<Vec<u8>>>`, which avoids expensive cloning of the file buffer between threads.

The `setattr` operation (for file truncation) is also handled correctly, ensuring that dirty regions are properly updated when the file size changes.