### PR TITLE
Fix deadlock in DiskImageWorker

### DIFF
--- a/src/disk_image.rs
+++ b/src/disk_image.rs
@@ -212,16 +212,18 @@ impl DiskImageWorker {
                 };
 
                 if let Some(data) = data_to_write {
-                    let fs_path = disk_image.get_fs_path(&path);
-                    let file = fs::OpenOptions::new().write(true).open(&fs_path)?;
-                    let data = data.read().unwrap();
-                    for (start, end) in regions {
-                        let start = start as usize;
-                        let end = end as usize;
-                        if end > data.len() {
-                            continue;
+                    {
+                        let fs_path = disk_image.get_fs_path(&path);
+                        let file = fs::OpenOptions::new().write(true).open(&fs_path)?;
+                        let data = data.read().unwrap();
+                        for (start, end) in regions {
+                            let start = start as usize;
+                            let end = end as usize;
+                            if end > data.len() {
+                                continue;
+                            }
+                            file.write_all_at(&data[start..end], start as u64)?;
                         }
-                        file.write_all_at(&data[start..end], start as u64)?;
                     }
 
                     // Now re-acquire lock to update state


### PR DESCRIPTION
I've fixed a deadlock that could occur when `git init` is called in the mounted filesystem. The issue was a lock ordering conflict between the `Nodes` RwLock and the `FileContent` RwLock.

The FUSE implementation acquires locks in the order `Nodes` -> `FileContent`, while the `DiskImageWorker` was acquiring them in the reverse order, `FileContent` -> `Nodes`.

To resolve this, I modified the `DiskImageWorker` to release its lock on `FileContent` before attempting to acquire a lock on `Nodes`. I achieved this by introducing a new scope for the file I/O operations, ensuring the read guard on the file content is dropped before the `DiskImageWorker` tries to acquire the `Nodes` lock.