### PR TITLE
fix: Correctly terminate the disk image worker thread

### DIFF
--- a/src/disk_image.rs
+++ b/src/disk_image.rs
@@ -300,8 +300,10 @@ impl DiskImageWorker {
         self.work_queue.clone()
     }
 
-    pub fn stop(&mut self) {
-        drop(self.work_queue.clone());
+    pub fn stop(mut self) {
+        // By taking ownership of self, the work_queue sender is dropped when
+        // this function returns, which will cause the worker thread to exit.
+        drop(self.work_queue);
         if let Some(worker_thread) = self.worker_thread.take() {
             worker_thread.join().unwrap();
         }


### PR DESCRIPTION
The `DiskImageWorker::stop` function was incorrectly trying to close the worker channel by dropping a clone of the sender, rather than the sender itself. This meant the channel was never closed, and the worker thread would block indefinitely, causing the main process to hang on unmount.

This commit fixes the issue by changing `stop()` to take ownership of `self`, which ensures that the `work_queue` sender is dropped and the channel is closed, allowing the worker thread to terminate gracefully.