### PR TITLE
fix: Prevent race condition when transitioning file content to OnDisk

### DIFF
--- a/mem_fuse.log
+++ b/mem_fuse.log
@@ -1,0 +1,7 @@
+error: unexpected argument '--mount-point' found
+
+  tip: to pass '--mount-point' as a value, use '-- --mount-point'
+
+Usage: mem_fuse [OPTIONS] <PATH>
+
+For more information, try '--help'.

--- a/src/disk_image.rs
+++ b/src/disk_image.rs
@@ -231,7 +231,11 @@ impl DiskImageWorker {
                     if let Ok(node) = nodes.get_mut(ino) {
                         if let NodeKind::File(file) = &mut node.kind {
                             if !file.dirty {
-                                file.content = FileContent::OnDisk;
+                                if let FileContent::InMemory(current_data) = &file.content {
+                                    if Arc::ptr_eq(&data, current_data) {
+                                        file.content = FileContent::OnDisk;
+                                    }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
A race condition could occur when a file's content was being written to the disk image. The DiskImageWorker thread would write the file's in-memory data to disk and then transition the file's state to `FileContent::OnDisk`.

The issue was that between the start of the write operation and the state transition, the file's in-memory content could be updated by another thread. The worker thread only checked a `dirty` flag, which was not sufficient to detect this change. This could lead to the new in-memory content being discarded and the file being represented by stale data on disk, causing data corruption and `SIGBUS` errors when the file was later accessed.

This fix resolves the race condition by adding a check using `Arc::ptr_eq`. Before transitioning the file state to `OnDisk`, the worker now verifies that the `Arc` holding the data it just wrote to disk is the same `Arc` that is currently active for the file. This ensures that the file content has not been replaced during the write operation, preventing data loss and ensuring data consistency.