### PR TITLE
feat: Add option for lazy loading from disk image

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,9 @@ pub struct FuseCommand {
     /// The size of the lru cache in Mb
     #[arg(long, default_value_t = 500)]
     cache_size: u64,
+    /// Load files from the disk image lazily
+    #[arg(long, default_value_t = false)]
+    lazy_load: bool,
 }
 
 fn main() -> Result<(), Box<dyn Error + Sync + Send>> {
@@ -38,6 +41,7 @@ fn main() -> Result<(), Box<dyn Error + Sync + Send>> {
         path,
         config.disk_image_path,
         config.cache_size * 1024 * 1024,
+        config.lazy_load,
     )?;
 
     Ok(())
@@ -47,8 +51,9 @@ fn start_fuse(
     path: &Path,
     disk_image_path: Option<PathBuf>,
     cache_size: u64,
+    lazy_load: bool,
 ) -> Result<(), Box<dyn Error + Sync + Send>> {
-    let filesystem = mem_fuse::MemoryFuse::new(disk_image_path, cache_size);
+    let filesystem = mem_fuse::MemoryFuse::new(disk_image_path, cache_size, lazy_load);
     fuser::mount2(filesystem, path, &[])?;
     Ok(())
 }


### PR DESCRIPTION
This commit introduces an option to lazily load files and directories from a disk image.

When the `--lazy-load` flag is used, the filesystem will only load the root directory from the disk image initially. Subdirectories and files are marked as `OnDisk` and are loaded on-demand when they are accessed through filesystem operations like `lookup` or `readdir`.

The key changes are:
- A `--lazy-load` command-line flag in `src/main.rs`.
- `DirectoryKind` enum in `src/node.rs` to represent `InMemory` and `OnDisk` directories.
- Logic in `MemoryFuse::new` in `src/mem_fuse.rs` to handle the initial lazy load.
- A `load_directory` method in `MemoryFuse` to perform on-demand loading.
- Updates to FUSE handlers to trigger lazy loading.
- A new test case for the lazy loading feature.

The code is currently in a non-compiling state due to a borrow-checker issue in `src/mem_fuse.rs` that I was actively working on resolving.