### PR TITLE
This commit refactors the application to make the disk image more abs…

### DIFF
--- a/src/mirror_factory.rs
+++ b/src/mirror_factory.rs
@@ -1,0 +1,15 @@
+use std::sync::Arc;
+use crate::mirror::{LocalMirror, Mirror};
+use crate::web_mirror::WebMirror;
+
+pub fn create_mirror(mirror_str: &str) -> Arc<dyn Mirror + Send + Sync> {
+    if mirror_str.starts_with("file://") {
+        let path = mirror_str.strip_prefix("file://").unwrap();
+        Arc::new(LocalMirror::new(path.into()))
+    } else if mirror_str.starts_with("http://") || mirror_str.starts_with("https://") {
+        Arc::new(WebMirror::new(mirror_str))
+    } else {
+        // Default to local mirror for plain paths
+        Arc::new(LocalMirror::new(mirror_str.into()))
+    }
+}

--- a/src/web_mirror.rs
+++ b/src/web_mirror.rs
@@ -1,0 +1,71 @@
+use std::{
+    fs::{self},
+    path::{Path, PathBuf},
+};
+
+use fuser::FileAttr;
+
+use crate::mirror::Mirror;
+
+#[derive(Debug)]
+pub struct WebMirror {
+    // To be implemented later
+}
+
+impl WebMirror {
+    pub fn new(_base_url: &str) -> Self {
+        // To be implemented later
+        Self {}
+    }
+}
+
+impl Mirror for WebMirror {
+    fn read_dir(&self, _path: &Path) -> std::io::Result<Vec<fs::DirEntry>> {
+        unimplemented!()
+    }
+
+    fn read_link(&self, _path: &Path) -> std::io::Result<PathBuf> {
+        unimplemented!()
+    }
+
+    fn read_file(&self, _path: &Path) -> std::io::Result<Vec<u8>> {
+        unimplemented!()
+    }
+
+    fn create_file(&self, _path: &Path, _attr: &FileAttr) -> std::io::Result<()> {
+        unimplemented!()
+    }
+
+    fn create_dir(&self, _path: &Path, _attr: &FileAttr) -> std::io::Result<()> {
+        unimplemented!()
+    }
+
+    fn create_symlink(
+        &self,
+        _target: &Path,
+        _link_path: &Path,
+        _attr: &FileAttr,
+    ) -> std::io::Result<()> {
+        unimplemented!()
+    }
+
+    fn write(&self, _path: &Path, _data: &[u8], _offset: u64) -> std::io::Result<()> {
+        unimplemented!()
+    }
+
+    fn set_attr(&self, _path: &Path, _attr: &FileAttr, _size: Option<u64>) -> std::io::Result<()> {
+        unimplemented!()
+    }
+
+    fn delete(&self, _path: &Path) -> std::io::Result<()> {
+        unimplemented!()
+    }
+
+    fn rename(&self, _old_path: &Path, _new_path: &Path) -> std::io::Result<()> {
+        unimplemented!()
+    }
+
+    fn link(&self, _source_path: &Path, _link_path: &Path) -> std::io::Result<()> {
+        unimplemented!()
+    }
+}


### PR DESCRIPTION
…tract, allowing for different types of mirrors to be used as a backend.

The main changes are:
- The `--disk-image-path` command-line argument has been replaced with a more generic `--mirror` argument.
- A `mirror_factory` has been introduced to create the appropriate mirror based on the provided mirror string (e.g., `file://...`).
- A placeholder `WebMirror` has been added to demonstrate how a new mirror type can be implemented in the future.

This change decouples the core logic from the specific mirror implementation, making the application more extensible.