### PR TITLE
Refactor Mirror trait to use inode and PathResolver

### DIFF
--- a/src/dirty.rs
+++ b/src/dirty.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct DirtyRegions {
     regions: BTreeSet<(u64, u64)>,
 }

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -34,6 +34,30 @@ pub fn build_path(nodes: &Nodes, ino: u64) -> Result<PathBuf> {
     Err(ENOENT)
 }
 
+fn to_io_error<T>(res: Result<T>) -> std::io::Result<T> {
+    res.map_err(|e| std::io::Error::from_raw_os_error(e))
+}
+
+pub struct PathResolver<'a> {
+    nodes: &'a Arc<RwLock<Nodes>>,
+}
+
+impl<'a> PathResolver<'a> {
+    pub fn new(nodes: &'a Arc<RwLock<Nodes>>) -> Self {
+        Self { nodes }
+    }
+
+    pub fn resolve(&self, ino: u64) -> std::io::Result<PathBuf> {
+        let nodes = self.nodes.read().unwrap();
+        to_io_error(build_path(&nodes, ino))
+    }
+
+    pub fn resolve_parent(&self, parent: u64, name: &OsString) -> std::io::Result<PathBuf> {
+        let parent_path = self.resolve(parent)?;
+        Ok(parent_path.join(name))
+    }
+}
+
 #[derive(Debug)]
 pub enum WriteJob {
     CreateFile {
@@ -109,41 +133,24 @@ impl MirrorWorker {
         job: WriteJob,
     ) -> std::io::Result<()> {
         debug!("Executing job: {job:?}");
+        let path_resolver = PathResolver::new(nodes);
         match job {
             WriteJob::CreateFile { parent, name, attr } => {
-                let path = {
-                    let nodes = nodes.read().unwrap();
-                    let parent_path = build_path(&nodes, parent).map_err(|e| std::io::Error::from_raw_os_error(e))?;
-                    parent_path.join(name)
-                };
-                mirror.create_file(&path, &attr)?;
+                mirror.create_file(parent, &name, &attr, &path_resolver)?;
             }
             WriteJob::CreateDir { parent, name, attr } => {
-                let path = {
-                    let nodes = nodes.read().unwrap();
-                    let parent_path = build_path(&nodes, parent).map_err(|e| std::io::Error::from_raw_os_error(e))?;
-                    parent_path.join(name)
-                };
-                mirror.create_dir(&path, &attr)?;
+                mirror.create_dir(parent, &name, &attr, &path_resolver)?;
             }
-            WriteJob::CreateSymlink { parent, name, target, attr } => {
-                let path = {
-                    let nodes = nodes.read().unwrap();
-                    let parent_path = build_path(&nodes, parent).map_err(|e| std::io::Error::from_raw_os_error(e))?;
-                    parent_path.join(name)
-                };
-                mirror.create_symlink(&target, &path, &attr)?;
+            WriteJob::CreateSymlink {
+                parent,
+                name,
+                target,
+                attr,
+            } => {
+                mirror.create_symlink(parent, &name, &target, &attr, &path_resolver)?;
             }
             WriteJob::Write { ino } => {
-                let (path, data_to_write, regions) = {
-                    let path = {
-                        let nodes = nodes.read().unwrap();
-                        match build_path(&nodes, ino) {
-                            Ok(p) => p,
-                            Err(_) => return Ok(()), // Node not found, nothing to do
-                        }
-                    };
-
+                let (data_to_write, regions) = {
                     let mut nodes = nodes.write().unwrap();
                     let node = match nodes.get_mut(ino) {
                         Ok(n) => n,
@@ -158,9 +165,9 @@ impl MirrorWorker {
                         let regions = file.dirty_regions.regions().clone();
                         file.dirty_regions.clear();
                         if let FileContent::InMemory(data) = &file.content {
-                            (path, Some(data.clone()), regions)
+                            (Some(data.clone()), regions)
                         } else {
-                            (path, None, regions)
+                            (None, regions)
                         }
                     } else {
                         return Ok(());
@@ -175,45 +182,30 @@ impl MirrorWorker {
                         if end > data.len() {
                             continue;
                         }
-                        mirror.write(&path, &data[start..end], start as u64)?;
+                        mirror.write(ino, &data[start..end], start as u64, &path_resolver)?;
                     }
                 }
             }
             WriteJob::SetAttr { ino, attr } => {
-                let path = {
-                    let nodes = nodes.read().unwrap();
-                    build_path(&nodes, ino).map_err(|e| std::io::Error::from_raw_os_error(e))?
-                };
-                mirror.set_attr(&path, &attr, Some(attr.size))?;
+                mirror.set_attr(ino, &attr, Some(attr.size), &path_resolver)?;
             }
             WriteJob::Delete { parent, name } => {
-                let path = {
-                    let nodes = nodes.read().unwrap();
-                    let parent_path = build_path(&nodes, parent).map_err(|e| std::io::Error::from_raw_os_error(e))?;
-                    parent_path.join(name)
-                };
-                mirror.delete(&path)?;
+                mirror.delete(parent, &name, &path_resolver)?;
             }
-            WriteJob::Rename { parent, name, new_parent, new_name } => {
-                let (old_path, new_path) = {
-                    let nodes = nodes.read().unwrap();
-                    let old_parent_path = build_path(&nodes, parent).map_err(|e| std::io::Error::from_raw_os_error(e))?;
-                    let old_path = old_parent_path.join(name);
-                    let new_parent_path = build_path(&nodes, new_parent).map_err(|e| std::io::Error::from_raw_os_error(e))?;
-                    let new_path = new_parent_path.join(new_name);
-                    (old_path, new_path)
-                };
-                mirror.rename(&old_path, &new_path)?;
+            WriteJob::Rename {
+                parent,
+                name,
+                new_parent,
+                new_name,
+            } => {
+                mirror.rename(parent, &name, new_parent, &new_name, &path_resolver)?;
             }
-            WriteJob::Link { ino, new_parent, new_name } => {
-                let (source_path, link_path) = {
-                    let nodes = nodes.read().unwrap();
-                    let source_path = build_path(&nodes, ino).map_err(|e| std::io::Error::from_raw_os_error(e))?;
-                    let new_parent_path = build_path(&nodes, new_parent).map_err(|e| std::io::Error::from_raw_os_error(e))?;
-                    let link_path = new_parent_path.join(new_name);
-                    (source_path, link_path)
-                };
-                mirror.link(&source_path, &link_path)?;
+            WriteJob::Link {
+                ino,
+                new_parent,
+                new_name,
+            } => {
+                mirror.link(ino, new_parent, &new_name, &path_resolver)?;
             }
         }
         Ok(())
@@ -235,17 +227,61 @@ impl MirrorWorker {
 }
 
 pub trait Mirror: Debug {
-    fn read_dir(&self, path: &Path) -> std::io::Result<Vec<fs::DirEntry>>;
-    fn read_link(&self, path: &Path) -> std::io::Result<PathBuf>;
-    fn read_file(&self, path: &Path) -> std::io::Result<Vec<u8>>;
-    fn create_file(&self, path: &Path, attr: &FileAttr) -> std::io::Result<()>;
-    fn create_dir(&self, path: &Path, attr: &FileAttr) -> std::io::Result<()>;
-    fn create_symlink(&self, target: &Path, link_path: &Path, attr: &FileAttr) -> std::io::Result<()>;
-    fn write(&self, path: &Path, data: &[u8], offset: u64) -> std::io::Result<()>;
-    fn set_attr(&self, path: &Path, attr: &FileAttr, size: Option<u64>) -> std::io::Result<()>;
-    fn delete(&self, path: &Path) -> std::io::Result<()>;
-    fn rename(&self, old_path: &Path, new_path: &Path) -> std::io::Result<()>;
-    fn link(&self, source_path: &Path, link_path: &Path) -> std::io::Result<()>;
+    fn read_dir<'a>(&self, ino: u64, path_resolver: &PathResolver<'a>) -> std::io::Result<Vec<fs::DirEntry>>;
+    fn read_link<'a>(&self, ino: u64, path_resolver: &PathResolver<'a>) -> std::io::Result<PathBuf>;
+    fn read_file<'a>(&self, ino: u64, path_resolver: &PathResolver<'a>) -> std::io::Result<Vec<u8>>;
+    fn create_file<'a>(
+        &self,
+        parent: u64,
+        name: &OsString,
+        attr: &FileAttr,
+        path_resolver: &PathResolver<'a>,
+    ) -> std::io::Result<()>;
+    fn create_dir<'a>(
+        &self,
+        parent: u64,
+        name: &OsString,
+        attr: &FileAttr,
+        path_resolver: &PathResolver<'a>,
+    ) -> std::io::Result<()>;
+    fn create_symlink<'a>(
+        &self,
+        parent: u64,
+        name: &OsString,
+        target: &Path,
+        attr: &FileAttr,
+        path_resolver: &PathResolver<'a>,
+    ) -> std::io::Result<()>;
+    fn write<'a>(
+        &self,
+        ino: u64,
+        data: &[u8],
+        offset: u64,
+        path_resolver: &PathResolver<'a>,
+    ) -> std::io::Result<()>;
+    fn set_attr<'a>(
+        &self,
+        ino: u64,
+        attr: &FileAttr,
+        size: Option<u64>,
+        path_resolver: &PathResolver<'a>,
+    ) -> std::io::Result<()>;
+    fn delete<'a>(&self, parent: u64, name: &OsString, path_resolver: &PathResolver<'a>) -> std::io::Result<()>;
+    fn rename<'a>(
+        &self,
+        parent: u64,
+        name: &OsString,
+        new_parent: u64,
+        new_name: &OsString,
+        path_resolver: &PathResolver<'a>,
+    ) -> std::io::Result<()>;
+    fn link<'a>(
+        &self,
+        ino: u64,
+        new_parent: u64,
+        new_name: &OsString,
+        path_resolver: &PathResolver<'a>,
+    ) -> std::io::Result<()>;
 }
 
 #[derive(Debug, Clone)]
@@ -273,8 +309,9 @@ impl LocalMirror {
 }
 
 impl Mirror for LocalMirror {
-    fn read_dir(&self, path: &Path) -> std::io::Result<Vec<fs::DirEntry>> {
-        let fs_path = self.get_fs_path(path);
+    fn read_dir<'a>(&self, ino: u64, path_resolver: &PathResolver<'a>) -> std::io::Result<Vec<fs::DirEntry>> {
+        let path = path_resolver.resolve(ino)?;
+        let fs_path = self.get_fs_path(&path);
         let mut entries = Vec::new();
         for entry in fs::read_dir(fs_path)? {
             entries.push(entry?);
@@ -282,18 +319,27 @@ impl Mirror for LocalMirror {
         Ok(entries)
     }
 
-    fn read_link(&self, path: &Path) -> std::io::Result<PathBuf> {
-        let fs_path = self.get_fs_path(path);
+    fn read_link<'a>(&self, ino: u64, path_resolver: &PathResolver<'a>) -> std::io::Result<PathBuf> {
+        let path = path_resolver.resolve(ino)?;
+        let fs_path = self.get_fs_path(&path);
         fs::read_link(fs_path)
     }
 
-    fn read_file(&self, path: &Path) -> std::io::Result<Vec<u8>> {
-        let fs_path = self.get_fs_path(path);
+    fn read_file<'a>(&self, ino: u64, path_resolver: &PathResolver<'a>) -> std::io::Result<Vec<u8>> {
+        let path = path_resolver.resolve(ino)?;
+        let fs_path = self.get_fs_path(&path);
         fs::read(fs_path)
     }
 
-    fn create_file(&self, path: &Path, attr: &FileAttr) -> std::io::Result<()> {
-        let fs_path = self.get_fs_path(path);
+    fn create_file<'a>(
+        &self,
+        parent: u64,
+        name: &OsString,
+        attr: &FileAttr,
+        path_resolver: &PathResolver<'a>,
+    ) -> std::io::Result<()> {
+        let path = path_resolver.resolve_parent(parent, name)?;
+        let fs_path = self.get_fs_path(&path);
         if let Some(parent) = fs_path.parent() {
             fs::create_dir_all(parent)?;
         }
@@ -303,31 +349,60 @@ impl Mirror for LocalMirror {
         chown(&fs_path, Some(attr.uid), Some(attr.gid))
     }
 
-    fn create_dir(&self, path: &Path, attr: &FileAttr) -> std::io::Result<()> {
-        let fs_path = self.get_fs_path(path);
+    fn create_dir<'a>(
+        &self,
+        parent: u64,
+        name: &OsString,
+        attr: &FileAttr,
+        path_resolver: &PathResolver<'a>,
+    ) -> std::io::Result<()> {
+        let path = path_resolver.resolve_parent(parent, name)?;
+        let fs_path = self.get_fs_path(&path);
         fs::create_dir_all(&fs_path)?;
         let perm = fs::Permissions::from_mode(attr.perm as u32);
         fs::set_permissions(&fs_path, perm)?;
         chown(&fs_path, Some(attr.uid), Some(attr.gid))
     }
 
-    fn create_symlink(&self, target: &Path, link_path: &Path, attr: &FileAttr) -> std::io::Result<()> {
-        let fs_path = self.get_fs_path(link_path);
+    fn create_symlink<'a>(
+        &self,
+        parent: u64,
+        name: &OsString,
+        target: &Path,
+        attr: &FileAttr,
+        path_resolver: &PathResolver<'a>,
+    ) -> std::io::Result<()> {
+        let link_path = path_resolver.resolve_parent(parent, name)?;
+        let fs_path = self.get_fs_path(&link_path);
         if let Some(parent) = fs_path.parent() {
             fs::create_dir_all(parent)?;
         }
-        symlink(&target, &fs_path)?;
+        symlink(target, &fs_path)?;
         chown(&fs_path, Some(attr.uid), Some(attr.gid))
     }
 
-    fn write(&self, path: &Path, data: &[u8], offset: u64) -> std::io::Result<()> {
-        let fs_path = self.get_fs_path(path);
+    fn write<'a>(
+        &self,
+        ino: u64,
+        data: &[u8],
+        offset: u64,
+        path_resolver: &PathResolver<'a>,
+    ) -> std::io::Result<()> {
+        let path = path_resolver.resolve(ino)?;
+        let fs_path = self.get_fs_path(&path);
         let file = fs::OpenOptions::new().write(true).open(&fs_path)?;
         file.write_all_at(data, offset)
     }
 
-    fn set_attr(&self, path: &Path, attr: &FileAttr, size: Option<u64>) -> std::io::Result<()> {
-        let fs_path = self.get_fs_path(path);
+    fn set_attr<'a>(
+        &self,
+        ino: u64,
+        attr: &FileAttr,
+        size: Option<u64>,
+        path_resolver: &PathResolver<'a>,
+    ) -> std::io::Result<()> {
+        let path = path_resolver.resolve(ino)?;
+        let fs_path = self.get_fs_path(&path);
         let perm = fs::Permissions::from_mode(attr.perm as u32);
         fs::set_permissions(&fs_path, perm)?;
         chown(&fs_path, Some(attr.uid), Some(attr.gid))?;
@@ -339,8 +414,9 @@ impl Mirror for LocalMirror {
         Ok(())
     }
 
-    fn delete(&self, path: &Path) -> std::io::Result<()> {
-        let fs_path = self.get_fs_path(path);
+    fn delete<'a>(&self, parent: u64, name: &OsString, path_resolver: &PathResolver<'a>) -> std::io::Result<()> {
+        let path = path_resolver.resolve_parent(parent, name)?;
+        let fs_path = self.get_fs_path(&path);
         if fs_path.is_dir() {
             fs::remove_dir(fs_path)
         } else {
@@ -348,15 +424,32 @@ impl Mirror for LocalMirror {
         }
     }
 
-    fn rename(&self, old_path: &Path, new_path: &Path) -> std::io::Result<()> {
-        let old_fs_path = self.get_fs_path(old_path);
-        let new_fs_path = self.get_fs_path(new_path);
+    fn rename<'a>(
+        &self,
+        parent: u64,
+        name: &OsString,
+        new_parent: u64,
+        new_name: &OsString,
+        path_resolver: &PathResolver<'a>,
+    ) -> std::io::Result<()> {
+        let old_path = path_resolver.resolve_parent(parent, name)?;
+        let new_path = path_resolver.resolve_parent(new_parent, new_name)?;
+        let old_fs_path = self.get_fs_path(&old_path);
+        let new_fs_path = self.get_fs_path(&new_path);
         fs::rename(old_fs_path, new_fs_path)
     }
 
-    fn link(&self, source_path: &Path, link_path: &Path) -> std::io::Result<()> {
-        let source_fs_path = self.get_fs_path(source_path);
-        let link_fs_path = self.get_fs_path(link_path);
+    fn link<'a>(
+        &self,
+        ino: u64,
+        new_parent: u64,
+        new_name: &OsString,
+        path_resolver: &PathResolver<'a>,
+    ) -> std::io::Result<()> {
+        let source_path = path_resolver.resolve(ino)?;
+        let link_path = path_resolver.resolve_parent(new_parent, new_name)?;
+        let source_fs_path = self.get_fs_path(&source_path);
+        let link_fs_path = self.get_fs_path(&link_path);
         if let Some(parent) = link_fs_path.parent() {
             fs::create_dir_all(parent)?;
         }

--- a/src/node.rs
+++ b/src/node.rs
@@ -12,6 +12,7 @@ use libc::{EEXIST, ENOENT, ENOTDIR};
 
 use crate::{dirty::DirtyRegions, mem_fuse::{OrError, Result}};
 
+#[derive(Clone)]
 pub struct Directory {
     entries: IndexMap<OsString, u64>,
 }
@@ -53,6 +54,7 @@ impl Directory {
     }
 }
 
+#[derive(Clone)]
 pub enum FileContent {
     InMemory(Arc<RwLock<Vec<u8>>>),
     OnDisk,
@@ -64,6 +66,7 @@ impl FileContent {
     }
 }
 
+#[derive(Clone)]
 pub struct File {
     pub content: FileContent,
     pub dirty: bool,
@@ -88,6 +91,7 @@ impl File {
     }
 }
 
+#[derive(Clone)]
 pub enum DirectoryKind {
     InMemory(Directory),
     OnDisk,
@@ -99,12 +103,14 @@ impl DirectoryKind {
     }
 }
 
+#[derive(Clone)]
 pub enum NodeKind {
     File(File),
     Directory(DirectoryKind),
     SymbolicLink { target: PathBuf },
 }
 
+#[derive(Clone)]
 pub struct Node {
     pub kind: NodeKind,
     pub attr: FileAttr,
@@ -194,6 +200,7 @@ impl Node {
     }
 }
 
+#[derive(Clone)]
 pub struct Nodes {
     nodes: HashMap<u64, Node>,
     parents: HashMap<u64, Vec<(u64, OsString)>>,

--- a/src/web_mirror.rs
+++ b/src/web_mirror.rs
@@ -1,11 +1,12 @@
 use std::{
+    ffi::OsString,
     fs::{self},
     path::{Path, PathBuf},
 };
 
 use fuser::FileAttr;
 
-use crate::mirror::Mirror;
+use crate::mirror::{Mirror, PathResolver};
 
 #[derive(Debug)]
 pub struct WebMirror {
@@ -20,52 +21,91 @@ impl WebMirror {
 }
 
 impl Mirror for WebMirror {
-    fn read_dir(&self, _path: &Path) -> std::io::Result<Vec<fs::DirEntry>> {
+    fn read_dir<'a>(&self, _ino: u64, _path_resolver: &PathResolver<'a>) -> std::io::Result<Vec<fs::DirEntry>> {
         unimplemented!()
     }
 
-    fn read_link(&self, _path: &Path) -> std::io::Result<PathBuf> {
+    fn read_link<'a>(&self, _ino: u64, _path_resolver: &PathResolver<'a>) -> std::io::Result<PathBuf> {
         unimplemented!()
     }
 
-    fn read_file(&self, _path: &Path) -> std::io::Result<Vec<u8>> {
+    fn read_file<'a>(&self, _ino: u64, _path_resolver: &PathResolver<'a>) -> std::io::Result<Vec<u8>> {
         unimplemented!()
     }
 
-    fn create_file(&self, _path: &Path, _attr: &FileAttr) -> std::io::Result<()> {
-        unimplemented!()
-    }
-
-    fn create_dir(&self, _path: &Path, _attr: &FileAttr) -> std::io::Result<()> {
-        unimplemented!()
-    }
-
-    fn create_symlink(
+    fn create_file<'a>(
         &self,
-        _target: &Path,
-        _link_path: &Path,
+        _parent: u64,
+        _name: &OsString,
         _attr: &FileAttr,
+        _path_resolver: &PathResolver<'a>,
     ) -> std::io::Result<()> {
         unimplemented!()
     }
 
-    fn write(&self, _path: &Path, _data: &[u8], _offset: u64) -> std::io::Result<()> {
+    fn create_dir<'a>(
+        &self,
+        _parent: u64,
+        _name: &OsString,
+        _attr: &FileAttr,
+        _path_resolver: &PathResolver<'a>,
+    ) -> std::io::Result<()> {
         unimplemented!()
     }
 
-    fn set_attr(&self, _path: &Path, _attr: &FileAttr, _size: Option<u64>) -> std::io::Result<()> {
+    fn create_symlink<'a>(
+        &self,
+        _parent: u64,
+        _name: &OsString,
+        _target: &Path,
+        _attr: &FileAttr,
+        _path_resolver: &PathResolver<'a>,
+    ) -> std::io::Result<()> {
         unimplemented!()
     }
 
-    fn delete(&self, _path: &Path) -> std::io::Result<()> {
+    fn write<'a>(
+        &self,
+        _ino: u64,
+        _data: &[u8],
+        _offset: u64,
+        _path_resolver: &PathResolver<'a>,
+    ) -> std::io::Result<()> {
         unimplemented!()
     }
 
-    fn rename(&self, _old_path: &Path, _new_path: &Path) -> std::io::Result<()> {
+    fn set_attr<'a>(
+        &self,
+        _ino: u64,
+        _attr: &FileAttr,
+        _size: Option<u64>,
+        _path_resolver: &PathResolver<'a>,
+    ) -> std::io::Result<()> {
         unimplemented!()
     }
 
-    fn link(&self, _source_path: &Path, _link_path: &Path) -> std::io::Result<()> {
+    fn delete<'a>(&self, _parent: u64, _name: &OsString, _path_resolver: &PathResolver<'a>) -> std::io::Result<()> {
+        unimplemented!()
+    }
+
+    fn rename<'a>(
+        &self,
+        _parent: u64,
+        _name: &OsString,
+        _new_parent: u64,
+        _new_name: &OsString,
+        _path_resolver: &PathResolver<'a>,
+    ) -> std::io::Result<()> {
+        unimplemented!()
+    }
+
+    fn link<'a>(
+        &self,
+        _ino: u64,
+        _new_parent: u64,
+        _new_name: &OsString,
+        _path_resolver: &PathResolver<'a>,
+    ) -> std::io::Result<()> {
         unimplemented!()
     }
 }


### PR DESCRIPTION
Refactor the Mirror trait to pass inode numbers and a PathResolver instead of raw paths. This allows for more flexible mirror implementations that may not require a path.

The main changes are:
- A new `PathResolver` struct is introduced to handle the resolution of inodes to paths.
- The `Mirror` trait and its implementations (`LocalMirror`, `WebMirror`) are updated to use inodes and the `PathResolver`.
- The `MirrorWorker` is updated to use the new `Mirror` interface.
- `mem_fuse.rs` is updated to work with the new `Mirror` interface, including changes to `MemoryFuse::new`, `load_directory`, and other functions that interact with the mirror.
- The `Node` struct and its components are made `Clone` to support the new implementation.