### PR TITLE
feat: Add ino to create_file, create_dir, and create_symlink

### DIFF
--- a/src/mem_fuse.rs
+++ b/src/mem_fuse.rs
@@ -351,7 +351,7 @@ impl MemoryFuse {
         if let Some(worker) = &self.mirror_worker {
             worker
                 .sender()
-                .send(WriteJob::CreateFile { parent, name: name.to_owned(), attr })
+                .send(WriteJob::CreateFile { ino: attr.ino, parent, name: name.to_owned(), attr })
                 .unwrap();
         }
         let node = Node::new_file(attr);
@@ -381,7 +381,7 @@ impl MemoryFuse {
         if let Some(worker) = &self.mirror_worker {
             worker
                 .sender()
-                .send(WriteJob::CreateDir { parent, name: name.to_owned(), attr })
+                .send(WriteJob::CreateDir { ino: attr.ino, parent, name: name.to_owned(), attr })
                 .unwrap();
         }
         let node = Node::new_directory(attr);
@@ -412,6 +412,7 @@ impl MemoryFuse {
             worker
                 .sender()
                 .send(WriteJob::CreateSymlink {
+                    ino: attr.ino,
                     parent,
                     name: link_name.to_owned(),
                     target: target.to_path_buf(),

--- a/src/web_mirror.rs
+++ b/src/web_mirror.rs
@@ -35,6 +35,7 @@ impl Mirror for WebMirror {
 
     fn create_file<'a>(
         &self,
+        _ino: u64,
         _parent: u64,
         _name: &OsString,
         _attr: &FileAttr,
@@ -45,6 +46,7 @@ impl Mirror for WebMirror {
 
     fn create_dir<'a>(
         &self,
+        _ino: u64,
         _parent: u64,
         _name: &OsString,
         _attr: &FileAttr,
@@ -55,6 +57,7 @@ impl Mirror for WebMirror {
 
     fn create_symlink<'a>(
         &self,
+        _ino: u64,
         _parent: u64,
         _name: &OsString,
         _target: &Path,


### PR DESCRIPTION
The create_file, create_dir, and create_symlink methods in the Mirror trait now accept the ino of the new file/directory. This allows Mirror implementations that do not use the path resolver to know which node is being referred to.

The WriteJob enum has been updated to carry the ino, and the LocalMirror and WebMirror implementations have been updated to match the new trait definition.