### PR TITLE
`MemoryFuse::load_directory` now generates unique `ino` values for ea…

### DIFF
--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     ffi::OsString,
     fmt::Debug,
     fs,
@@ -312,6 +313,10 @@ pub trait Mirror: Debug {
         new_name: &OsString,
         path_resolver: &PathResolver<'a>,
     ) -> std::io::Result<()>;
+
+    fn set_inode_map(&self, _ino_map: &HashMap<u64, u64>) -> std::io::Result<()> {
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
…ch file and directory loaded from a mirror, preventing potential `ino` conflicts.

A new method, `set_inode_map`, has been added to the `Mirror` trait. This allows `MemoryFuse` to send a mapping of its newly generated `ino` values to the original `ino` values from the mirror.

The `WebMirror` implements `set_inode_map` to update its internal `ino` mapping, ensuring that it can correctly translate between local and remote `ino`s. The `read_dir`, `read_link`, and `read_file` methods in `WebMirror` have also been updated to correctly use this mapping.

The `LocalMirror` uses the default empty implementation of `set_inode_map`, as it does not require the `ino` mapping.