### PR TITLE
This commit introduces a configurable limit on the memory used for fi…

### DIFF
--- a/src/lru_cache.rs
+++ b/src/lru_cache.rs
@@ -1,5 +1,6 @@
-use std::sync::{Arc, Condvar, RwLock};
+use std::sync::{Arc, Condvar, Mutex, RwLock};
 use lru::LruCache;
+use libc;
 
 use crate::node::{NodeKind, Nodes};
 
@@ -9,19 +10,21 @@ struct CacheData {
 }
 
 pub struct LruManager {
-    data: RwLock<CacheData>,
+    data: Mutex<CacheData>,
     max_size: u64,
+    max_write_size: u64,
     cache_cond: Arc<Condvar>,
 }
 
 impl LruManager {
-    pub fn new(max_size: u64, cache_cond: Arc<Condvar>) -> Self {
+    pub fn new(max_size: u64, max_write_size: u64, cache_cond: Arc<Condvar>) -> Self {
         Self {
-            data: RwLock::new(CacheData {
+            data: Mutex::new(CacheData {
                 cache: LruCache::unbounded(),
                 current_size: 0,
             }),
             max_size,
+            max_write_size,
             cache_cond,
         }
     }
@@ -31,23 +34,54 @@ impl LruManager {
         ino: u64,
         content: Arc<RwLock<Vec<u8>>>,
         nodes: &Arc<RwLock<Nodes>>,
-    ) -> Vec<(u64, Arc<RwLock<Vec<u8>>>)> {
-        let mut data = self.data.write().unwrap();
+        has_mirror: bool,
+    ) -> Result<Vec<(u64, Arc<RwLock<Vec<u8>>>)>, libc::c_int> {
         let content_len = content.read().unwrap().len() as u64;
+        let mut data = self.data.lock().unwrap();
+
+        if data.current_size + content_len > self.max_write_size {
+            if has_mirror {
+                while data.current_size + content_len > self.max_write_size {
+                    data = self.cache_cond.wait(data).unwrap();
+                }
+            } else {
+                // Before returning an error, try to evict some clean files to make space.
+                // This is a simplified eviction pass. A more thorough one happens below.
+                // We only do this if there's no mirror, as a last ditch effort.
+                Self::evict_clean(&mut data, self.max_size, ino, nodes);
+                if data.current_size + content_len > self.max_write_size {
+                    return Err(libc::ENOSPC);
+                }
+            }
+        }
+
         let mut evicted = Vec::new();
 
         if let Some((_old_content, old_len)) = data.cache.put(ino, (content.clone(), content_len)) {
             data.current_size -= old_len;
         }
-
         data.current_size += content_len;
 
-        while data.current_size > self.max_size {
+        Self::evict_clean(&mut data, self.max_size, ino, nodes)
+            .into_iter()
+            .for_each(|item| evicted.push(item));
+
+        self.cache_cond.notify_all();
+        Ok(evicted)
+    }
+
+    fn evict_clean(data: &mut std::sync::MutexGuard<CacheData>, max_size: u64, current_ino: u64, nodes: &Arc<RwLock<Nodes>>) -> Vec<(u64, Arc<RwLock<Vec<u8>>>)> {
+        let mut evicted = Vec::new();
+        // Evict files that are not dirty
+        // We do this until the cache size is below the max_size
+        // Note that we may still be above max_size if the cache is full of dirty files
+        // that cannot be evicted.
+        while data.current_size > max_size {
             let mut evicted_one = false;
             let keys: Vec<u64> = data.cache.iter().map(|(k, _v)| *k).collect();
 
             for key_to_evict in keys.iter().rev() {
-                if *key_to_evict == ino {
+                if *key_to_evict == current_ino {
                     continue;
                 }
                 let is_dirty = {
@@ -77,16 +111,16 @@ impl LruManager {
                 break;
             }
         }
-        self.cache_cond.notify_all();
         evicted
     }
 
+
     pub fn get(&self, ino: &u64) -> Option<Arc<RwLock<Vec<u8>>>> {
-        self.data.write().unwrap().cache.get_mut(ino).map(|(c, _)| c.clone())
+        self.data.lock().unwrap().cache.get_mut(ino).map(|(c, _)| c.clone())
     }
 
     pub fn remove(&self, ino: &u64) {
-        let mut data = self.data.write().unwrap();
+        let mut data = self.data.lock().unwrap();
         if let Some((_content, content_len)) = data.cache.pop(ino) {
             data.current_size -= content_len;
         }


### PR DESCRIPTION
…le caches, preventing unbounded memory growth when writing files.

A new command-line flag, `--cache-max-write-size`, is added to specify this limit, defaulting to 1GB.

When a write operation would cause the cache size to exceed this limit, the behavior is as follows:
- If a mirror is configured, the operation blocks, waiting for the mirror worker to write dirty pages to disk and free up memory. This creates backpressure on the writer.
- If no mirror is configured, and the cache is full of dirty files that cannot be evicted, the write operation will fail with an `ENOSPC` (No space left on device) error.

This change includes:
- Modifications to `LruManager` to enforce the new limit, using a `Condvar` to block and unblock waiting threads.
- Updates to `MemoryFuse` to plumb the new configuration and handle the potential `ENOSPC` error.
- A signal from the `MirrorWorker` to the `LruManager` after writes are completed to unblock waiting writers.
- An updated test case to verify the new `ENOSPC` error behavior.