### PR TITLE
fix(lru): Fix hang in LRU eviction logic

### DIFF
--- a/src/lru_cache.rs
+++ b/src/lru_cache.rs
@@ -43,6 +43,7 @@ impl LruManager {
             if has_mirror {
                 while data.current_size + content_len > self.max_write_size {
                     data = self.cache_cond.wait(data).unwrap();
+                    Self::evict_clean(&mut data, self.max_size, ino, nodes);
                 }
             } else {
                 // Before returning an error, try to evict some clean files to make space.


### PR DESCRIPTION
The `LruManager::put` function could hang indefinitely when the cache was full of dirty files. The thread would wait on a condition variable for space to be freed, but upon waking up, it would not re-evaluate if any files had become clean and evictable.

This was a classic "lost wakeup" problem. The `MirrorWorker` would correctly write a file to the mirror, mark it as clean, and notify the waiting thread. However, the waiting thread would wake up, see that the cache size had not changed, and immediately go back to waiting.

The fix is to call the `evict_clean` function immediately after the thread wakes up from waiting on the condition variable. This ensures that it attempts to evict any newly cleaned files, which reduces the cache size and allows the operation to proceed, resolving the hang.