### PR TITLE
Feat: Implement block-based storage for in-memory files

### DIFF
--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -196,12 +196,13 @@ impl MirrorWorker {
                 if let Some(data) = data_to_write {
                     let data = data.read().unwrap();
                     for (start, end) in regions {
-                        let start = start as usize;
-                        let end = end as usize;
-                        if end > data.len() {
+                        let start = start as u64;
+                        let end = end as u64;
+                        if end > data.length {
                             continue;
                         }
-                        mirror.write(ino, &data[start..end], start as u64, &path_resolver)?;
+                        let data_to_write = data.read(start, (end - start) as u32);
+                        mirror.write(ino, &data_to_write, start, &path_resolver)?;
                     }
                 }
                 lru_manager.mark_as_clean(ino);

--- a/src/tests/block_storage_tests.rs
+++ b/src/tests/block_storage_tests.rs
@@ -1,0 +1,54 @@
+#[test]
+fn test_write_read_single_block() {
+    let mut file_blocks = FileBlocks::new(1024);
+    let data = "hello world".as_bytes();
+    file_blocks.write(0, data);
+    let read_data = file_blocks.read(0, data.len() as u32);
+    assert_eq!(data, read_data.as_slice());
+}
+
+#[test]
+fn test_write_read_multiple_blocks() {
+    let mut file_blocks = FileBlocks::new(1024);
+    let mut data = Vec::new();
+    for i in 0..2048 {
+        data.push((i % 256) as u8);
+    }
+    file_blocks.write(0, &data);
+    let read_data = file_blocks.read(0, data.len() as u32);
+    assert_eq!(data, read_data);
+}
+
+#[test]
+fn test_write_read_with_offset() {
+    let mut file_blocks = FileBlocks::new(1024);
+    let mut data = Vec::new();
+    for i in 0..2048 {
+        data.push((i % 256) as u8);
+    }
+    file_blocks.write(512, &data);
+    let read_data = file_blocks.read(512, data.len() as u32);
+    assert_eq!(data, read_data);
+}
+
+#[test]
+fn test_overwrite() {
+    let mut file_blocks = FileBlocks::new(1024);
+    let initial_data = "hello world".as_bytes();
+    file_blocks.write(0, initial_data);
+    let new_data = "goodbye".as_bytes();
+    file_blocks.write(6, new_data);
+    let read_data = file_blocks.read(0, "hello goodbye".len() as u32);
+    assert_eq!("hello goodbye", String::from_utf8(read_data).unwrap());
+}
+
+#[test]
+fn test_block_truncate() {
+    let mut file_blocks = FileBlocks::new(1024);
+    let data = "hello world".as_bytes();
+    file_blocks.write(0, data);
+    file_blocks.truncate(5);
+    let read_data = file_blocks.read(0, 5);
+    assert_eq!("hello".as_bytes(), read_data.as_slice());
+    assert_eq!(5, file_blocks.length);
+}

--- a/src/tests/lru_cache_tests.rs
+++ b/src/tests/lru_cache_tests.rs
@@ -1,9 +1,15 @@
 use crate::lru_cache::LruManager;
 
+fn create_file_blocks(data: &[u8]) -> FileBlocks {
+    let mut file_blocks = FileBlocks::new(1024);
+    file_blocks.write(0, data);
+    file_blocks
+}
+
 #[test]
 fn test_put_and_get() {
     let lru = LruManager::new(100, 100, std::sync::Arc::new(std::sync::Condvar::new()));
-    let content = std::sync::Arc::new(std::sync::RwLock::new(vec![1, 2, 3]));
+    let content = std::sync::Arc::new(std::sync::RwLock::new(create_file_blocks(&[1, 2, 3])));
     let put_result = lru.put(1, content.clone(), false, false);
     assert!(put_result.is_ok());
     assert!(put_result.unwrap().is_empty());
@@ -15,9 +21,9 @@ fn test_put_and_get() {
 #[test]
 fn test_lru_manager_eviction() {
     let lru = LruManager::new(10, 10, std::sync::Arc::new(std::sync::Condvar::new()));
-    let content1 = std::sync::Arc::new(std::sync::RwLock::new(vec![1; 5]));
-    let content2 = std::sync::Arc::new(std::sync::RwLock::new(vec![2; 5]));
-    let content3 = std::sync::Arc::new(std::sync::RwLock::new(vec![3; 5]));
+    let content1 = std::sync::Arc::new(std::sync::RwLock::new(create_file_blocks(&[1; 5])));
+    let content2 = std::sync::Arc::new(std::sync::RwLock::new(create_file_blocks(&[2; 5])));
+    let content3 = std::sync::Arc::new(std::sync::RwLock::new(create_file_blocks(&[3; 5])));
 
     assert!(lru.put(1, content1.clone(), false, false).unwrap().is_empty());
     assert!(lru.put(2, content2.clone(), false, false).unwrap().is_empty());
@@ -35,7 +41,7 @@ fn test_lru_manager_eviction() {
 #[test]
 fn test_remove() {
     let lru = LruManager::new(100, 100, std::sync::Arc::new(std::sync::Condvar::new()));
-    let content = std::sync::Arc::new(std::sync::RwLock::new(vec![1, 2, 3]));
+    let content = std::sync::Arc::new(std::sync::RwLock::new(create_file_blocks(&[1, 2, 3])));
     assert!(lru.put(1, content.clone(), false, false).unwrap().is_empty());
 
     lru.remove(&1);
@@ -45,28 +51,28 @@ fn test_remove() {
 #[test]
 fn test_mark_as_clean() {
     let lru = LruManager::new(100, 100, std::sync::Arc::new(std::sync::Condvar::new()));
-    let content = std::sync::Arc::new(std::sync::RwLock::new(vec![1, 2, 3]));
+    let content = std::sync::Arc::new(std::sync::RwLock::new(create_file_blocks(&[1, 2, 3])));
     assert!(lru.put(1, content.clone(), false, true).unwrap().is_empty());
 
     // Dirty size should be the size of the content.
     // We need to access internal state for this, which is not ideal.
     // For this test, we'll infer it from the behavior of put.
-    let content2 = std::sync::Arc::new(std::sync::RwLock::new(vec![0; 98]));
+    let content2 = std::sync::Arc::new(std::sync::RwLock::new(create_file_blocks(&[0; 98])));
     assert_eq!(lru.put(2, content2, false, true).unwrap_err(), libc::ENOSPC);
 
     lru.mark_as_clean(1);
 
-    let content3 = std::sync::Arc::new(std::sync::RwLock::new(vec![0; 98]));
+    let content3 = std::sync::Arc::new(std::sync::RwLock::new(create_file_blocks(&[0; 98])));
     assert!(lru.put(3, content3, false, true).is_ok());
 }
 
 #[test]
 fn test_max_write_size() {
     let lru = LruManager::new(100, 10, std::sync::Arc::new(std::sync::Condvar::new()));
-    let content1 = std::sync::Arc::new(std::sync::RwLock::new(vec![1; 5]));
+    let content1 = std::sync::Arc::new(std::sync::RwLock::new(create_file_blocks(&[1; 5])));
     assert!(lru.put(1, content1.clone(), false, true).unwrap().is_empty());
 
-    let content2 = std::sync::Arc::new(std::sync::RwLock::new(vec![2; 6]));
+    let content2 = std::sync::Arc::new(std::sync::RwLock::new(create_file_blocks(&[2; 6])));
     assert_eq!(lru.put(2, content2.clone(), false, true).unwrap_err(), libc::ENOSPC);
 
     // After marking the first one as clean, we should be able to add the second one.

--- a/src/tests/mirror_tests.rs
+++ b/src/tests/mirror_tests.rs
@@ -34,6 +34,7 @@ fn test_disk_mirroring() {
         500 * 1024 * 1024,
         500 * 1024 * 1024,
         false,
+        crate::node::DEFAULT_BLOCK_SIZE,
     );
 
     // 1. Create a directory
@@ -132,6 +133,7 @@ fn test_lru_eviction() {
         1024 * 1024,
         1024 * 1024,
         false,
+        crate::node::DEFAULT_BLOCK_SIZE,
     );
 
     // Create file 1 (0.6 MB)
@@ -199,7 +201,7 @@ fn test_lru_eviction() {
 #[test]
 fn test_lru_eviction_dirty() {
     // 1MB cache size, no disk worker
-    let mut fuse = MemoryFuse::new(None, 1024 * 1024, 1024 * 1024, false);
+    let mut fuse = MemoryFuse::new(None, 1024 * 1024, 1024 * 1024, false, crate::node::DEFAULT_BLOCK_SIZE);
 
     // Create file 1 (0.6 MB)
     let file1_name = OsStr::new("file1.txt");
@@ -239,6 +241,7 @@ fn test_lazy_load() {
         1024 * 1024,
         1024 * 1024,
         true,
+        crate::node::DEFAULT_BLOCK_SIZE,
     );
 
     // 3. Verify that initially, only the root directory is loaded


### PR DESCRIPTION
This change modifies the in-memory file storage to use blocks instead of a single large array. The block size is configurable via a command-line argument, defaulting to 1MB.

The following changes were made:
- Introduced a `FileBlocks` struct to manage file content in blocks.
- Updated `read_file`, `write_file`, and `set_attr` to work with `FileBlocks`.
- Added a `--block-size` command-line argument.
- Updated the LRU cache to handle `FileBlocks`.
- Added tests for the new block-based storage.