### PR TITLE
feat: Change block_size unit from MB to KB

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,8 +36,8 @@ pub struct FuseCommand {
     #[arg(short, long)]
     /// The root node of the invariant files server, ignored otherwise
     root: Option<u64>,
-    /// The block size for files in Mb
-    #[arg(long, default_value_t = 1)]
+    /// The block size for files in Kb
+    #[arg(long, default_value_t = 1024)]
     block_size: usize,
 }
 
@@ -56,7 +56,7 @@ fn main() -> Result<(), Box<dyn Error + Sync + Send>> {
         config.cache_max_write_size * 1024 * 1024,
         config.lazy_load,
         config.root,
-        config.block_size * 1024 * 1024,
+        config.block_size * 1024,
     )?;
 
     Ok(())


### PR DESCRIPTION
The `block_size` parameter was previously in units of 1 MB. This has been changed to be in units of 1K.

The command-line argument help text has been updated to reflect this change, and the default value has been adjusted to maintain the same effective default block size.