### PR TITLE
refactor: Move invariant_files_mirror tests to a separate file

### DIFF
--- a/src/invariant_files_mirror.rs
+++ b/src/invariant_files_mirror.rs
@@ -501,20 +501,3 @@ impl Mirror for InvariantFilesMirror {
         Ok(())
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use crate::invariant_files_mirror::{ContentInformation, FileDirectoryEntry};
-
-    #[test]
-    fn test_entries_deserialization() -> std::io::Result<()> {
-        let data = "[{\"name\":\".gitignore\",\"info\":{\"node\":2,\"kind\":\"File\",\"modifyTime\":1721419791909,\"createTime\":1721419791909,\"executable\":false,\"writable\":false,\"etag\":\"aae8e9997fb040fb78109337af8a9ee31d6649d7280a9f7fa61e3bcb7854709f\",\"size\":34}}]";
-        let entries:  Vec<FileDirectoryEntry>  = serde_json::from_str(data)?;
-        let entry = &entries[0];
-        assert_eq!(entry.name, ".gitignore");
-        if let ContentInformation::File(info) = &entry.info {
-            assert_eq!(info.size, 34);
-        }
-        Ok(())
-    }
-}

--- a/src/tests/invariant_files_mirror_tests.rs
+++ b/src/tests/invariant_files_mirror_tests.rs
@@ -1,0 +1,13 @@
+use crate::invariant_files_mirror::{ContentInformation, FileDirectoryEntry};
+
+#[test]
+fn test_entries_deserialization() -> std::io::Result<()> {
+    let data = "[{\"name\":\".gitignore\",\"info\":{\"node\":2,\"kind\":\"File\",\"modifyTime\":1721419791909,\"createTime\":1721419791909,\"executable\":false,\"writable\":false,\"etag\":\"aae8e9997fb040fb78109337af8a9ee31d6649d7280a9f7fa61e3bcb7854709f\",\"size\":34}}]";
+    let entries:  Vec<FileDirectoryEntry>  = serde_json::from_str(data)?;
+    let entry = &entries[0];
+    assert_eq!(entry.name, ".gitignore");
+    if let ContentInformation::File(info) = &entry.info {
+        assert_eq!(info.size, 34);
+    }
+    Ok(())
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -2,3 +2,4 @@ pub mod lru_cache_tests;
 pub mod dirty_tests;
 pub mod mirror_tests;
 pub mod block_storage_tests;
+pub mod invariant_files_mirror_tests;


### PR DESCRIPTION
Moved the inline tests from src/invariant_files_mirror.rs to their own file in src/tests/invariant_files_mirror_tests.rs. This follows the pattern of other tests in the project.